### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  [pull_request, push]
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        ocaml-version:
+          - 4.13.1
+          - 4.14.0
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-version }}
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
+
+      - name: Install dependencies
+        run: opam install . --deps-only --with-doc --verbose
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Run tests
+        run: opam exec -- dune runtest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
+        os: 
+          - ubuntu-latest
+          # Pending due to OCaml libraries installation error 
+          # - macos-latest
         ocaml-version:
           - 4.13.1
           - 4.14.0
@@ -28,7 +31,10 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ] ; then
-            sudo apt-get install -y protobuf grpcurl yarn
+            sudo apt-get install -y protobuf-compiler yarn
+            curl -sLO https://github.com/fullstorydev/grpcurl/releases/download/v1.8.6/grpcurl_1.8.6_linux_x86_64.tar.gz
+            tar -xvf grpcurl_1.8.6_linux_x86_64.tar.gz
+            sudo cp grpcurl /usr/local/bin
           else
             brew install protobuf grpcurl yarn
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,5 @@ jobs:
           opam pin add ocaml-protoc-plugin https://github.com/Nymphium/ocaml-protoc-plugin.git#create-rpc-path
           opam install . --deps-only --with-doc --verbose
 
-      - name: Build
-        run: opam exec -- dune build
-
       - name: Run tests
         run: opam exec -- dune runtest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             brew install protobuf grpcurl yarn
           fi
           
-          opam pin add ocaml-protoc-plugin https://github.com/Nymphium/ocaml-protoc-plugin#create-rpc-path
+          opam pin add ocaml-protoc-plugin https://github.com/Nymphium/ocaml-protoc-plugin.git#create-rpc-path
           opam install . --deps-only --with-doc --verbose
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
           dune-cache: ${{ matrix.os != 'macos-latest' }}
 
       - name: Install dependencies
-        run: opam install . --deps-only --with-doc --verbose
+        run: |
+          apt install protobuf grpcurl yarn # I don't know ubuntu has these pkgs or its correct name
+          opam pin add ocaml-protoc-plugin https://github.com/Nymphium/ocaml-protoc-plugin#create-rpc-path
+          opam install . --deps-only --with-doc --verbose
 
       - name: Build
         run: opam exec -- dune build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt install protobuf grpcurl yarn # I don't know ubuntu has these pkgs or its correct name
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ] ; then
+            sudo apt-get install -y protobuf grpcurl yarn
+          else
+            brew install protobuf grpcurl yarn
+          fi
+          
           opam pin add ocaml-protoc-plugin https://github.com/Nymphium/ocaml-protoc-plugin#create-rpc-path
           opam install . --deps-only --with-doc --verbose
 

--- a/grpc.opam
+++ b/grpc.opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_deriving"
   "ppx_yojson_conv"
   "ppx_let"
-  "fmt" { with-test }
+  "fmt"
   "ppx_inline_test" { with-test }
   "alcotest" { with-test }
 ]

--- a/grpc.opam
+++ b/grpc.opam
@@ -17,6 +17,7 @@ depends: [
   "ppx_deriving"
   "ppx_yojson_conv"
   "ppx_let"
+  "fmt"
   "ppx_inline_test" { with-test }
   "alcotest" { with-test }
 ]

--- a/grpc.opam
+++ b/grpc.opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_deriving"
   "ppx_yojson_conv"
   "ppx_let"
-  "fmt"
+  "fmt" { with-test }
   "ppx_inline_test" { with-test }
   "alcotest" { with-test }
 ]

--- a/grpc.opam
+++ b/grpc.opam
@@ -17,7 +17,6 @@ depends: [
   "ppx_deriving"
   "ppx_yojson_conv"
   "ppx_let"
-  "fmt"
   "ppx_inline_test" { with-test }
   "alcotest" { with-test }
 ]


### PR DESCRIPTION
~https://github.com/y-yu/grpc-ocaml/runs/6654576467?check_suite_focus=true~

<details>
```
Run opam exec -- dune build
(cd _build/default && /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bin-annot -I server/.grpc_server.objs/byte -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/angstrom -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/base_internalhash_types -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/caml -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/md5 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/shadow_stdlib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base64 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base_bigstring -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base_quickcheck -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bigarray-compat -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bigstringaf -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bin_prot -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bin_prot/shape -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/core -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/core/base_for_tests -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/core/validate -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/faraday -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/faraday-lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/faraday-lwt-unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/fieldslib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/gluten -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/gluten-lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/gluten-lwt-unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/h2 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/h2-lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/h2-lwt-unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/hmap -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/hpack -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/httpaf -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/int_repr -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/jane-street-headers -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/logs -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/lwt/unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/lwt_ssl -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/mmap -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocaml-protoc-plugin -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocaml/threads -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocplib-endian -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocplib-endian/bigstring -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/parsexp -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_assert/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_bench/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_compare/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_deriving/runtime -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_enumerate/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/collector -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/common -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/config -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/config_types -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_hash/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_here/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_inline_test/config -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_inline_test/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_log/types -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_module_timer/runtime -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_sexp_conv/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/psq -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/result -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/seq -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/sexplib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/sexplib0 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/splittable_random -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ssl -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/stdio -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/stringext -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/time_now -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/typerep -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/uri -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/variantslib -I basic/.Grpc_basic.objs/byte -no-alias-deps -opaque -open Grpc_server__ -o server/.grpc_server.objs/byte/grpc_server__Handler.cmo -c -impl server/handler.pp.ml)
File "server/handler.ml", line 23, characters 8-83:
23 |         (module PB.Service.Rpc with type Request.t = req and type Response.t = res)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module type PB.Service.Rpc
(cd _build/default && /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bin-annot -I client/.grpc_client.objs/byte -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/angstrom -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/base_internalhash_types -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/caml -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/md5 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base/shadow_stdlib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base64 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base_bigstring -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base_quickcheck -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bigarray-compat -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bigstringaf -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bin_prot -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/bin_prot/shape -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/core -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/core/base_for_tests -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/core/validate -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/faraday -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/faraday-lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/faraday-lwt-unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/fieldslib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/gluten -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/gluten-lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/gluten-lwt-unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/h2 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/h2-lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/h2-lwt-unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/hpack -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/httpaf -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/int_repr -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/jane-street-headers -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/logs -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/lwt -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/lwt/unix -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/lwt_ssl -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/mmap -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocaml-protoc-plugin -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocaml/threads -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocplib-endian -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ocplib-endian/bigstring -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/parsexp -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_assert/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_bench/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_compare/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_deriving/runtime -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_enumerate/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/collector -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/common -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/config -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_expect/config_types -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_hash/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_here/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_inline_test/config -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_inline_test/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_log/types -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_module_timer/runtime -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ppx_sexp_conv/runtime-lib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/psq -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/result -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/seq -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/sexplib -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/sexplib0 -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/splittable_random -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/ssl -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/stdio -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/stringext -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/time_now -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/typerep -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/uri -I /home/runner/work/grpc-ocaml/grpc-ocaml/_opam/lib/variantslib -I basic/.Grpc_basic.objs/byte -no-alias-deps -opaque -open Grpc_client__ -o client/.grpc_client.objs/byte/grpc_client__Client.cmo -c -impl client/client.pp.ml)
File "client/client.ml", lines 119-121, characters 6-37:
119 | ......(module Ocaml_protoc_plugin.Service.Rpc
120 |          with type Request.t = 'req
121 |           and type Response.t = 'res)
Error: Unbound module type Ocaml_protoc_plugin.Service.Rpc
```
</details>